### PR TITLE
Build on older distribution to lower glibc requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   # The Matrix Build
   # ===================================================
   build-rust:
-    name: Build Rust (${{ matrix.os }})
+    name: Build Rust (${{ matrix.os }} - ${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -29,6 +29,7 @@ jobs:
             rid: linux-x64
             artifact_name: libnative_shim.so
             use_cross: false
+            container_image: quay.io/pypa/manylinux_2_28_x86_64
             rustflags: "-C target-cpu=x86-64-v3"
 
           # --- Linux x64 Musl ---
@@ -36,16 +37,17 @@ jobs:
             target: x86_64-unknown-linux-musl
             rid: linux-musl-x64
             artifact_name: libnative_shim.so
-            use_cross: true 
+            use_cross: true
             rustflags: "-C target-feature=-crt-static -C target-cpu=x86-64-v3"
-            
+
           # --- Linux ARM64 glibc---
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             rid: linux-arm64
             artifact_name: libnative_shim.so
-            use_cross: true
-            
+            use_cross: false
+            container_image: quay.io/pypa/manylinux_2_28_aarch64
+
           # --- Linux ARM64 Musl ---
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
@@ -98,23 +100,40 @@ jobs:
         with:
           key: ${{ matrix.target }}
           workspaces: ./native_shim
-      
+
+      - name: Pull Container Image
+        if: matrix.container_image
+        run: docker pull ${{ matrix.container_image }}
+
       # Compile Rust (Release mode)
       - name: Build Native Shim
         shell: bash
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
         run: |
-          CARGO_CMD="cargo"
-          if [[ "${{ matrix.use_cross }}" == "true" ]]; then
-            CARGO_CMD="cross"
+          if [[ -n "${{ matrix.container_image }}" ]]; then
+            echo "Building for ${{ matrix.target }} inside ${{ matrix.container_image }}..."
+            echo "RUSTFLAGS: $RUSTFLAGS"
+            docker run --rm \
+              -v "${{ github.workspace }}:/workspace" \
+              -v "$HOME/.rustup:/root/.rustup" \
+              -v "$HOME/.cargo:/root/.cargo" \
+              -w /workspace/native_shim \
+              -e RUSTFLAGS="$RUSTFLAGS" \
+              -e RUSTUP_HOME=/root/.rustup \
+              -e CARGO_HOME=/root/.cargo \
+              ${{ matrix.container_image }} \
+              bash -c 'export PATH="/root/.cargo/bin:$PATH" && cargo build --release --target ${{ matrix.target }}'
+          else
+            CARGO_CMD="cargo"
+            if [[ "${{ matrix.use_cross }}" == "true" ]]; then
+              CARGO_CMD="cross"
+            fi
+            echo "Building for ${{ matrix.target }} using $CARGO_CMD..."
+            echo "RUSTFLAGS: $RUSTFLAGS"
+            cd native_shim
+            $CARGO_CMD build --release --target ${{ matrix.target }}
           fi
-          
-          echo "Building for ${{ matrix.target }} using $CARGO_CMD..."
-          echo "RUSTFLAGS: $RUSTFLAGS"
-
-          cd native_shim
-          $CARGO_CMD build --release --target ${{ matrix.target }}
 
       - name: Prepare Artifact
         shell: bash
@@ -206,6 +225,8 @@ jobs:
         include:
           - os: ubuntu-latest
             native_rid: linux-x64
+          - os: ubuntu-24.04-arm
+            native_rid: linux-arm64
           - os: windows-latest
             native_rid: win-x64
           - os: macos-14


### PR DESCRIPTION
## Summary

Fixes https://github.com/ErrorLSC/Polars.NET/issues/25
Build the Linux glibc native shims inside `manylinux_2_28` containers so the
produced `.so` files link against  glibc 2.28 and run on more Linux
distributions. 

The musl targets (linux-musl-x64 and linux-musl-arm64) are not affected by this change. They continue to build with cross as before; only the glibc targets (linux-x64 and linux-arm64) switch to building inside the manylinux_2_28 containers.

Note that cross-compiling arm64 from an x64 host inside the `manylinux_2_28_x86_64` container is not possible because package [gcc-aarch64-linux-gnu](https://packages.fedoraproject.org/pkgs/cross-gcc/gcc-aarch64-linux-gnu/) doesn't support building user space programs.
Instead, arm64 is built natively on an` ubuntu-24.04-arm` runner inside `manylinux_2_28_aarch64` container . We also reuse the Rust version installed via the "Install Rust Toolchain" step on the runner, keeping the in-container build consistent with the other targets.

